### PR TITLE
chore(deny): remove deprecated keys

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -62,16 +62,8 @@ feature-depth = 1
 db-path = "~/.cargo/advisory-db"
 # The url(s) of the advisory databases to use
 db-urls = ["https://github.com/rustsec/advisory-db"]
-# The lint level for security vulnerabilities
-vulnerability = "deny"
-# The lint level for unmaintained crates
-unmaintained = "warn"
 # The lint level for crates that have been yanked from their source registry
 yanked = "warn"
-# The lint level for crates with security notices. Note that as of
-# 2019-12-17 there are no security notice advisories in
-# https://github.com/rustsec/advisory-db
-notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = []
@@ -95,8 +87,6 @@ ignore = []
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-# The lint level for crates which do not have a detectable license
-unlicensed = "deny"
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
@@ -111,42 +101,6 @@ allow = [
     # why don't we allow? ;)
     "CC0-1.0"
 ]
-# List of explicitly disallowed licenses
-# See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-deny = [
-    "AGPL-1.0",
-    "AGPL-1.0",
-    "AGPL-3.0",
-    "AGPL-3.0",
-    "GPL-1.0",
-    "GPL-1.0",
-    "GPL-2.0",
-    "GPL-2.0",
-    "GPL-3.0",
-    "GPL-3.0",
-    "LGPL-2.0",
-    "LGPL-2.0",
-    "LGPL-2.1",
-    "LGPL-2.1",
-    "LGPL-3.0",
-    "LGPL-3.0",
-]
-
-# Lint level for licenses considered copyleft
-copyleft = "deny"
-# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
-# * both - The license will be approved if it is both OSI-approved *AND* FSF
-# * either - The license will be approved if it is either OSI-approved *OR* FSF
-# * osi - The license will be approved if is OSI-approved *AND NOT* FSF
-# * fsf - The license will be approved if is FSF *AND NOT* OSI-approved
-# * neither - This predicate is ignored and the default lint level is used
-allow-osi-fsf-free = "neither"
-# Lint level used when no other predicates are matched
-# 1. License isn't in the allow or deny lists
-# 2. License isn't copyleft
-# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
-default = "deny"
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.


### PR DESCRIPTION
partly addresses #391 

advisories:
- vulnerability: deny -> deny (no change)
- unmaintained: warn -> deny (stricter, no warnings)
- yanked: warn -> deny (stricter: no warnings)
- notice: warn -> deny (stricter, no warnings) 

licenses:
- unlicensed: deny -> deny (no change)
- deny: some -> none (effectively no change)
- allow-osi-fsf-free: neither -> neither (no change)
- copyleft: deny -> deny (no change)