### PR TITLE
chore(deps): upgrade rust crate bytes to 1.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,9 +139,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cc"


### PR DESCRIPTION
bytes@=1.6.0 is yanked: see https://github.com/tokio-rs/bytes/pull/718